### PR TITLE
fix(plasmaCash): add `targetBlock` to the transaction signed attributes

### DIFF
--- a/contracts/lib/Transaction.sol
+++ b/contracts/lib/Transaction.sol
@@ -13,6 +13,7 @@ library Transaction {
     uint256 depositId;
     uint256 prevTxBlockIndex;
     address newOwner;
+    uint256 targetBlock;
   }
 
   /// @dev this is ETH prefix, so we can be sure, data was signed in EVM
@@ -20,11 +21,12 @@ library Transaction {
 
   function createTransaction(bytes rlp) internal pure returns (TX memory) {
     RLP.RLPItem[] memory txList = rlp.toRLPItem().toList();
-    require(txList.length == 3, "txList.length == 3");
+    require(txList.length == 4, "txList.length == 4");
     return TX({
       depositId: txList[0].toUint(),
       prevTxBlockIndex: txList[1].toUint(),
-      newOwner: txList[2].toAddress()
+      newOwner: txList[2].toAddress(),
+      targetBlock: txList[3].toUint()
     });
   }
 
@@ -36,6 +38,6 @@ library Transaction {
   internal
   pure
   returns (bytes32) {
-    return keccak256(abi.encodePacked(_tx.depositId, _tx.prevTxBlockIndex, _tx.newOwner));
+    return keccak256(abi.encodePacked(_tx.depositId, _tx.prevTxBlockIndex, _tx.newOwner, _tx.targetBlock));
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2882,24 +2882,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2909,12 +2913,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -2923,34 +2929,40 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "2.6.9",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2959,25 +2971,29 @@
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2986,13 +3002,15 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3008,7 +3026,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3022,13 +3041,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.21",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3037,7 +3058,8 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3046,7 +3068,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3056,18 +3079,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -3075,13 +3101,15 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -3089,12 +3117,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "minipass": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
           "requires": {
             "safe-buffer": "^5.1.1",
@@ -3103,7 +3133,8 @@
         },
         "minizlib": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3112,7 +3143,8 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -3120,13 +3152,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3137,7 +3171,8 @@
         },
         "node-pre-gyp": {
           "version": "0.10.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3155,7 +3190,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3165,13 +3201,15 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ByQ3oJ/5ETLyglU2+8dBObvhfWXX8dtPZDMePCahptliFX2iIuhyEszyFk401PZUNQH20vvdW5MLjJxkwU80Ow==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.1.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3181,7 +3219,8 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3193,18 +3232,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -3212,19 +3254,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3234,19 +3279,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3258,7 +3306,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -3266,7 +3315,8 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3281,7 +3331,8 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3290,42 +3341,49 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
           "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "^1.0.0",
@@ -3335,7 +3393,8 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3344,7 +3403,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -3352,13 +3412,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3373,13 +3435,15 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3388,12 +3452,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
           "dev": true
         }
       }

--- a/test/helpers/SpecHelper.js
+++ b/test/helpers/SpecHelper.js
@@ -1,0 +1,97 @@
+const moveChar = () => {
+  const rand = parseInt(Math.random() * 10, 10) % 4;
+  switch (rand) {
+    case 0: return '|';
+    case 1: return '/';
+    case 2: return '-';
+    case 3: return '\\';
+    default: return rand;
+  }
+};
+
+const writeProcessMsg = (msg, useMoveChar = true) => {
+  const lineLength = 118;
+  const s = useMoveChar ? msg + moveChar() : msg;
+  const spaces = lineLength - s.length > 0 ? ' '.repeat(lineLength - s.length) : '';
+  process.stderr.write(`${s}${spaces}\r`);
+};
+
+const moveForward = seconds => (
+  new Promise((resolve, reject) => {
+    web3.currentProvider.sendAsync({
+      method: 'evm_increaseTime',
+      params: [seconds],
+    }, (err, res) => {
+      if (err !== undefined && err !== null) {
+        reject(err);
+      }
+
+      resolve(res);
+    });
+  })
+);
+
+const advanceBlock = () => (
+  new Promise((resolve, reject) => {
+    writeProcessMsg('mining blocks... ');
+    web3.currentProvider.sendAsync({
+      jsonrpc: '2.0',
+      method: 'evm_mine',
+      id: Date.now(),
+    }, (err, res) => (err ? reject(err) : resolve(res)));
+  })
+);
+
+const advanceToBlock = async (number) => {
+  if (web3.eth.blockNumber > number) {
+    throw Error(`block number ${number} is in the past (current is ${web3.eth.blockNumber})`);
+  }
+
+  const awaits = [];
+
+  const blockCount = number - web3.eth.blockNumber;
+
+  Array(blockCount)
+    .fill()
+    .forEach(() => awaits.push(advanceBlock()));
+
+  return Promise.all(awaits);
+};
+
+const takeSnapshot = () => (
+  new Promise((resolve, reject) => {
+    web3.currentProvider.sendAsync({
+      method: 'evm_snapshot',
+    }, (err, res) => {
+      if (err !== undefined && err !== null) {
+        reject(err);
+      }
+
+      const id = parseInt(res, 16);
+      resolve(id);
+    });
+  })
+);
+
+const resetSnapshot = id => (
+  new Promise((resolve, reject) => {
+    web3.currentProvider.sendAsync({
+      method: 'evm_revert',
+      params: [id],
+    }, (err, res) => {
+      if (err !== undefined && err !== null) {
+        reject(err);
+      }
+
+      resolve(res);
+    });
+  })
+);
+
+export {
+  writeProcessMsg,
+  moveForward,
+  takeSnapshot,
+  resetSnapshot,
+  advanceToBlock,
+};

--- a/test/helpers/createScenarioObjects.js
+++ b/test/helpers/createScenarioObjects.js
@@ -7,7 +7,8 @@ const ministroPlasmaUtil = require('../ministro-contracts/ministroPlasma');
 
 const ministroPlasma = ministroPlasmaUtil();
 
-const challengeTimeoutSec = 50;
+const challengeTimeoutSec = 60 * 60 * 24;
+const challengeTimeoutSecPass = challengeTimeoutSec + 5;
 const exitBond = 1000;
 
 const scenarioObjects = async (accounts, noOfUsers) => {
@@ -39,4 +40,5 @@ export {
   challengeTimeoutSec,
   exitBond,
   scenarioObjects,
+  challengeTimeoutSecPass,
 };

--- a/test/lib/Transaction.js
+++ b/test/lib/Transaction.js
@@ -65,7 +65,7 @@ export default class Transaction {
   }
 
   toRLP() {
-    return RLP.encode([this.depositId, this.prevTxBlockIndex, this.newOwner]);
+    return RLP.encode([this.depositId, this.prevTxBlockIndex, this.newOwner, this.targetBlock]);
   }
 
   toRLPHex() {
@@ -85,7 +85,7 @@ export default class Transaction {
       { type: 'uint', value: this.depositId },
       { type: 'uint', value: this.prevTxBlockIndex },
       { type: 'address', value: this.newOwner },
-      // { type: 'uint', value: this.targetBlock },
+      { type: 'uint', value: this.targetBlock },
     ];
   }
 
@@ -146,11 +146,13 @@ export default class Transaction {
     const depositId = `0x${tx[0].toString('hex')}`;
     const prevTxBlockIndex = `0x${tx[1].toString('hex')}`;
     const newOwner = `0x${tx[2].toString('hex')}`;
+    const targetBlock = `0x${tx[3].toString('hex')}`;
 
     return {
       depositId: depositId === '0x' ? '0x0' : depositId,
       prevTxBlockIndex: prevTxBlockIndex === '0x' ? '0x0' : prevTxBlockIndex,
       newOwner,
+      targetBlock,
     };
   }
 }

--- a/test/ministro-contracts/ministroPlasma.js
+++ b/test/ministro-contracts/ministroPlasma.js
@@ -33,7 +33,7 @@ function ministroContract() {
       const block = await app.blocks(blockSubmitted.blockIndex.toString(10));
 
       assert.strictEqual(blockSubmitted.merkleRoot, block.merkleRoot, 'merkleRoot on blockchain is different');
-      assert(BigNumber(block.timestamp).minus(Date.now()).lt(60), 'block timeout is older that 60seconds, and it was just submitted');
+      assert(BigNumber(block.timestamp).gt(0), 'block timestamp is empty');
     }
 
     return results;
@@ -92,7 +92,6 @@ function ministroContract() {
     assert.strictEqual(executor, txAttrLocal.from, 'invalid executor');
     assert(BigNumber(depositId).eq(depNonce), 'invalid deposit nonce');
     assert(BigNumber(blockIndex).eq(blkIndex), 'invalid blkIndex');
-
     assert(BigNumber(finalizeTime).gt(timeBeforeTx), 'invalid finalizeTime');
 
     const {
@@ -124,7 +123,6 @@ function ministroContract() {
     proof,
     signature,
     spender,
-    targetBlock,
     txAttr,
     expectThrow,
   ) => {
@@ -136,7 +134,6 @@ function ministroContract() {
       proof,
       signature,
       spender,
-      targetBlock,
       txAttrLocal,
     );
 
@@ -150,7 +147,7 @@ function ministroContract() {
       await app.assertStartExit(
         results,
         tx.depositId,
-        targetBlock,
+        tx.targetBlock,
         txAttrLocal,
         currTimestamp,
       );
@@ -166,13 +163,12 @@ function ministroContract() {
     transactionBytes,
     proof,
     signature,
-    targetBlock,
     txAttr,
     expectThrow,
   ) => {
     const txAttrLocal = app.getTxAttr(txAttr);
     const action = () => app.instance.challengeExit(
-      transactionBytes, proof, signature, targetBlock, txAttrLocal,
+      transactionBytes, proof, signature, txAttrLocal,
     );
 
     const prevBalance = expectThrow ? null : await app.balances(txAttrLocal.from);
@@ -285,9 +281,10 @@ function ministroContract() {
   app.chainBlockIndex = async () => app.instance.chainBlockIndex.call();
   app.operators = async addr => app.instance.operators.call(addr);
 
-  app.exitQueue = async (depositId) => {
-    app.instance.exitQueue.call(BigNumber(depositId).toString(10));
-  };
+  app.getExitQueue = async (depositId, index) => app.instance.exitQueue.call(
+    BigNumber(depositId).toString(10),
+    BigNumber(index).toString(10),
+  );
 
   app.exits = async (depositId, blockIndex) => {
     const res = await app.instance.exits.call(

--- a/test/scenarios/TestTx_4_withheldBlock.js
+++ b/test/scenarios/TestTx_4_withheldBlock.js
@@ -1,7 +1,7 @@
 import { BigNumber } from 'bignumber.js';
 import { assert } from 'chai';
-import { scenarioObjects, exitBond, challengeTimeoutSec } from '../helpers/createScenarioObjects';
-import { CurrentTimestamp } from '../helpers/binary';
+import { scenarioObjects, exitBond, challengeTimeoutSecPass } from '../helpers/createScenarioObjects';
+import { moveForward } from '../helpers/SpecHelper';
 
 let ministroPlasma;
 let plasmaOperator;
@@ -9,8 +9,6 @@ let plasmaOperator;
 let users;
 const usersDeposits = [1, 2, 4, 8];
 const txs = [];
-
-let startExitTime = 0;
 
 contract('Plasma Cash', async (accounts) => {
   before(async () => {
@@ -95,7 +93,6 @@ contract('Plasma Cash', async (accounts) => {
               proof,
               tx.signature,
               tx.sender,
-              tx.targetBlock,
               { from: users[3].address, value: exitBond },
               true,
             );
@@ -114,11 +111,8 @@ contract('Plasma Cash', async (accounts) => {
                 proof,
                 tx.signature,
                 tx.sender,
-                tx.targetBlock,
                 { from: users[1].address, value: exitBond },
               );
-
-              startExitTime = CurrentTimestamp();
             });
 
 
@@ -133,7 +127,6 @@ contract('Plasma Cash', async (accounts) => {
                 transactionBytes,
                 proof,
                 tx.signature,
-                tx.targetBlock,
                 { from: users[2].address },
                 true,
               );
@@ -141,19 +134,8 @@ contract('Plasma Cash', async (accounts) => {
 
 
             describe('when challenge Timeout pass for both exits (no challenges)', async () => {
-              before((done) => {
-                const deltaTime = BigNumber(CurrentTimestamp()).minus(startExitTime);
-                const msDelay = BigNumber(challengeTimeoutSec + 3)
-                  .minus(deltaTime)
-                  .times(1000)
-                  .toString(10);
-
-                if (BigNumber(msDelay).lte(0)) done();
-                else {
-                  setTimeout(() => {
-                    done();
-                  }, msDelay);
-                }
+              before(async () => {
+                await moveForward(challengeTimeoutSecPass);
               });
 
               describe('when we finalize exits on spent deposit', async () => {


### PR DESCRIPTION
This security fix will prevent from stealing the money for all cases, where operator should include user block, but he did not. Not placing transaction on `targetBlock` automatically makes that transaction invalid.
User can start exit on that transaction, but then the right owner will start an exit on previous one and he has the priority. It is not possible to challenge right owner with invalid transaction,
because plasma root for `targetBlock` will not match.